### PR TITLE
feat: Define data models for weather API response

### DIFF
--- a/composeApp/src/commonMain/kotlin/dev/androidpoet/weatherapp/domain/model/CurrentWeather.kt
+++ b/composeApp/src/commonMain/kotlin/dev/androidpoet/weatherapp/domain/model/CurrentWeather.kt
@@ -1,0 +1,14 @@
+package dev.androidpoet.weatherapp.domain.model
+
+import kotlinx.serialization.Serializable
+
+
+@Serializable
+data class CurrentWeather(
+    val temp: Double,
+    val sunrise: Long,
+    val sunset: Long,
+    val uvi: Double,
+    val weather: List<WeatherDescription>
+)
+

--- a/composeApp/src/commonMain/kotlin/dev/androidpoet/weatherapp/domain/model/DailyData.kt
+++ b/composeApp/src/commonMain/kotlin/dev/androidpoet/weatherapp/domain/model/DailyData.kt
@@ -1,0 +1,12 @@
+package dev.androidpoet.weatherapp.domain.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DailyData(
+    val dt: Long,
+    val temp: DailyTemp,
+    val weather: List<WeatherDescription>,
+    val summary: String? = null,
+)
+

--- a/composeApp/src/commonMain/kotlin/dev/androidpoet/weatherapp/domain/model/DailyTemp.kt
+++ b/composeApp/src/commonMain/kotlin/dev/androidpoet/weatherapp/domain/model/DailyTemp.kt
@@ -1,0 +1,10 @@
+package dev.androidpoet.weatherapp.domain.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DailyTemp(
+    val min: Double,
+    val max: Double
+)
+

--- a/composeApp/src/commonMain/kotlin/dev/androidpoet/weatherapp/domain/model/HourlyData.kt
+++ b/composeApp/src/commonMain/kotlin/dev/androidpoet/weatherapp/domain/model/HourlyData.kt
@@ -1,0 +1,12 @@
+package dev.androidpoet.weatherapp.domain.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HourlyData(
+    val dt: Long,
+    val temp: Double,
+    val weather: List<WeatherDescription>,
+    val pop: Double
+)
+

--- a/composeApp/src/commonMain/kotlin/dev/androidpoet/weatherapp/domain/model/WeatherApiResponse.kt
+++ b/composeApp/src/commonMain/kotlin/dev/androidpoet/weatherapp/domain/model/WeatherApiResponse.kt
@@ -1,0 +1,12 @@
+package dev.androidpoet.weatherapp.domain.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WeatherApiResponse(
+    val timezone: String,
+    val timezoneOffset: Int,
+    val current: CurrentWeather,
+    val hourly: List<HourlyData> = emptyList(),
+    val daily: List<DailyData> = emptyList()
+)

--- a/composeApp/src/commonMain/kotlin/dev/androidpoet/weatherapp/domain/model/WeatherDescription.kt
+++ b/composeApp/src/commonMain/kotlin/dev/androidpoet/weatherapp/domain/model/WeatherDescription.kt
@@ -1,0 +1,10 @@
+package dev.androidpoet.weatherapp.domain.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WeatherDescription(
+    val main: String,
+    val description: String,
+    val icon: String
+)


### PR DESCRIPTION
This commit introduces data classes to represent the structure of the weather API response. 
Closes #4 

The following models have been created:
- `WeatherApiResponse`: Top-level response object.
- `CurrentWeather`: Represents current weather conditions.
- `HourlyData`: Represents weather data for an hour.
- `DailyData`: Represents weather data for a day.
- `DailyTemp`: Represents minimum and maximum daily temperatures.
- `WeatherDescription`: Contains main weather condition, description, and icon.

All models are annotated with `@Serializable` for Kotlin serialization.

This is the `Api Response` we get 

``` 
                
{
   "lat":33.44,
   "lon":-94.04,
   "timezone":"America/Chicago",
   "timezone_offset":-18000,
   "current":{
      "dt":1684929490,
      "sunrise":1684926645,
      "sunset":1684977332,
      "temp":292.55,
      "feels_like":292.87,
      "pressure":1014,
      "humidity":89,
      "dew_point":290.69,
      "uvi":0.16,
      "clouds":53,
      "visibility":10000,
      "wind_speed":3.13,
      "wind_deg":93,
      "wind_gust":6.71,
      "weather":[
         {
            "id":803,
            "main":"Clouds",
            "description":"broken clouds",
            "icon":"04d"
         }
      ]
   },
   "minutely":[
      {
         "dt":1684929540,
         "precipitation":0
      },
      ...
   ],
   "hourly":[
      {
         "dt":1684926000,
         "temp":292.01,
         "feels_like":292.33,
         "pressure":1014,
         "humidity":91,
         "dew_point":290.51,
         "uvi":0,
         "clouds":54,
         "visibility":10000,
         "wind_speed":2.58,
         "wind_deg":86,
         "wind_gust":5.88,
         "weather":[
            {
               "id":803,
               "main":"Clouds",
               "description":"broken clouds",
               "icon":"04n"
            }
         ],
         "pop":0.15
      },
      ...
   ],
   "daily":[
      {
         "dt":1684951200,
         "sunrise":1684926645,
         "sunset":1684977332,
         "moonrise":1684941060,
         "moonset":1684905480,
         "moon_phase":0.16,
         "summary":"Expect a day of partly cloudy with rain",
         "temp":{
            "day":299.03,
            "min":290.69,
            "max":300.35,
            "night":291.45,
            "eve":297.51,
            "morn":292.55
         },
         "feels_like":{
            "day":299.21,
            "night":291.37,
            "eve":297.86,
            "morn":292.87
         },
         "pressure":1016,
         "humidity":59,
         "dew_point":290.48,
         "wind_speed":3.98,
         "wind_deg":76,
         "wind_gust":8.92,
         "weather":[
            {
               "id":500,
               "main":"Rain",
               "description":"light rain",
               "icon":"10d"
            }
         ],
         "clouds":92,
         "pop":0.47,
         "rain":0.15,
         "uvi":9.23
      },
      ...
   ],
    "alerts": [
    {
      "sender_name": "NWS Philadelphia - Mount Holly (New Jersey, Delaware, Southeastern Pennsylvania)",
      "event": "Small Craft Advisory",
      "start": 1684952747,
      "end": 1684988747,
      "description": "...SMALL CRAFT ADVISORY REMAINS IN EFFECT FROM 5 PM THIS\nAFTERNOON TO 3 AM EST FRIDAY...\n* WHAT...North winds 15 to 20 kt with gusts up to 25 kt and seas\n3 to 5 ft expected.\n* WHERE...Coastal waters from Little Egg Inlet to Great Egg\nInlet NJ out 20 nm, Coastal waters from Great Egg Inlet to\nCape May NJ out 20 nm and Coastal waters from Manasquan Inlet\nto Little Egg Inlet NJ out 20 nm.\n* WHEN...From 5 PM this afternoon to 3 AM EST Friday.\n* IMPACTS...Conditions will be hazardous to small craft.",
      "tags": [

      ]
    },
    ...
  ]
                
              
```